### PR TITLE
Don't set color column for diagnostics window.

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -430,7 +430,7 @@ func! s:DiagnosticsWindowOpen(src, diags)
   setl buftype=nofile bufhidden=hide
   setl noswapfile nobuflisted nowrap nonumber nospell nomodifiable winfixheight winfixwidth
   setl cursorline
-  setl colorcolumn=-1
+  setl colorcolumn=
 
   " Don't use indentLine in the diagnostics window
   " See https://github.com/Yggdroot/indentLine.git


### PR DESCRIPTION
Since the diagnostics window is set `nowrap` and not modifiable by the user, I don't see a benefit in having a `textwidth` relative color column explicitly enabled for this window.

On the contrary, since the color column depends on an arbitrary global setting, it only clutters the windows contents and slows down rendering.